### PR TITLE
fix: refresh behaviour

### DIFF
--- a/reporter/internal/html.go
+++ b/reporter/internal/html.go
@@ -399,7 +399,6 @@ const templateHTML = `
 	</body>
 	<script>
 	const initialID = '{{.InitialID}}';
-	window.location.hash = initialID;
 
 	window.renderView = () => {
 		for (const view of document.getElementsByClassName('view')) {


### PR DESCRIPTION
removing initial set of window.location.hash which allows to refresh the page between coverage runs and stay on the same block of code (useful when running coverage locally)